### PR TITLE
fix: events page having misplaced / mis-sorted event listings

### DIFF
--- a/packages/ypiretis/app/components/frontpage/calendar_grid.tsx
+++ b/packages/ypiretis/app/components/frontpage/calendar_grid.tsx
@@ -30,7 +30,7 @@ import CalendarTextIcon from "~/components/icons/calendar_text_icon";
 import PinIcon from "~/components/icons/pin_icon";
 
 import type {IDateLike} from "~/utils/datetime";
-import {toDate, useTimezone, zeroDay} from "~/utils/datetime";
+import {toDate, useTimezone} from "~/utils/datetime";
 import {formatCalendarWeekdays} from "~/utils/locale";
 
 const CONTEXT_CALENDAR_GRID = createContext<ICalendarGridContext | null>(null);

--- a/packages/ypiretis/app/components/frontpage/calendar_grid.tsx
+++ b/packages/ypiretis/app/components/frontpage/calendar_grid.tsx
@@ -114,11 +114,13 @@ export interface ICalendarGridDay {
 }
 
 export interface ICalendarGridEvent {
-    readonly id: string;
+    readonly dayTimestamp: IDateLike;
 
     readonly description: string;
 
     readonly endAtTimestamp?: IDateLike;
+
+    readonly id: string;
 
     readonly location?: string;
 
@@ -143,13 +145,14 @@ function makeEventDayLookup(
     const dayLookup = new Map<number, ICalendarGridEvent[]>();
 
     for (const event of events) {
-        const {startAtTimestamp: startAt} = event;
-        const date = zeroDay(startAt);
+        const {dayTimestamp} = event;
 
+        const date = toDate(dayTimestamp);
         const epochMilliseconds = date.getTime();
-        const events = dayLookup.get(epochMilliseconds) ?? [];
 
+        const events = dayLookup.get(epochMilliseconds) ?? [];
         events.push(event);
+
         dayLookup.set(epochMilliseconds, events);
     }
 
@@ -324,8 +327,8 @@ function CalendarGridItem(props: ICalenderGridItemProps) {
 
     const {date, isInMonth, isWeekend} = day;
 
-    const dayTimestamp = zeroDay(date).getTime();
-    const events = dayLookup.get(dayTimestamp) ?? null;
+    const epochMilliseconds = date.getTime();
+    const events = dayLookup.get(epochMilliseconds) ?? null;
 
     return (
         <VStack

--- a/packages/ypiretis/app/routes/_frontpage_.calendar.($year).($month).tsx
+++ b/packages/ypiretis/app/routes/_frontpage_.calendar.($year).($month).tsx
@@ -124,8 +124,15 @@ export async function loader(loaderArgs: Route.LoaderArgs) {
             const {content, endAt, eventID, location, slug, startAt, title} =
                 event;
 
-            const zonedPublishedAt =
-                startAt.toZonedDateTimeISO(SERVER_TIMEZONE);
+            const zonedStartAt = startAt.toZonedDateTimeISO(SERVER_TIMEZONE);
+            const zonedDay = zonedStartAt.with({
+                hour: 0,
+                minute: 0,
+                second: 0,
+                microsecond: 0,
+                millisecond: 0,
+                nanosecond: 0,
+            });
 
             const plaintextContent = await renderMarkdownForPlaintext(content);
             const description = normalizeSpacing(
@@ -136,12 +143,14 @@ export async function loader(loaderArgs: Route.LoaderArgs) {
             );
 
             const endAtTimestamp = endAt?.epochMilliseconds ?? null;
+            const {epochMilliseconds: dayTimestamp} = zonedDay;
             const {epochMilliseconds: startAtTimestamp} = startAt;
 
-            const {year, month, day} = zonedPublishedAt;
+            const {year, month, day} = zonedStartAt;
 
             return {
                 day,
+                dayTimestamp,
                 description,
                 endAtTimestamp,
                 eventID,
@@ -334,6 +343,7 @@ function EventCalendar() {
         return events.map((event) => {
             const {
                 day,
+                dayTimestamp,
                 description,
                 endAtTimestamp,
                 eventID,
@@ -350,6 +360,7 @@ function EventCalendar() {
             }) satisfies ICalenderGridEventTemplate;
 
             return {
+                dayTimestamp,
                 description,
                 template,
                 title,

--- a/packages/ypiretis/app/routes/_frontpage_.calendar.($year).($month).tsx
+++ b/packages/ypiretis/app/routes/_frontpage_.calendar.($year).($month).tsx
@@ -109,7 +109,7 @@ export async function loader(loaderArgs: Route.LoaderArgs) {
 
     const events = await findAllPublished({
         sort: {
-            by: "publishedAt",
+            by: "startAt",
             mode: SORT_MODES.descending,
         },
 

--- a/packages/ypiretis/package.json
+++ b/packages/ypiretis/package.json
@@ -2,7 +2,7 @@
     "private": true,
     "type": "module",
     "name": "orital-ypiretis",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "scripts": {
         "app:build": "NODE_ENV=production bunx --bun react-router build",
         "app:dev": "NODE_ENV=development bunx --bun vite",


### PR DESCRIPTION
The following bugs were fixed:

- Events were sorted by publishing timestamp rather than start timestamp.
- Events were placed in `CalendarGrid` by UTC date rather than localized timestamp date.